### PR TITLE
profiles/handheld: Remove cachyos-handheld from package list

### DIFF
--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -3,13 +3,13 @@ desc = 'Generic handheld profile'
 class_ids = "0601"
 hwd_product_name_pattern= '83E1|83L3|83N6|83Q2|83Q3|83N0|83N1|AIR|AOKZOE|AYANEO|AYA NEO FOUNDER|A2VM|A1M|BZ2EM|FLIP 1S DS|FLIP DS|FLIP KB|G1617-01|G1618-03|G1618-04|G1618-05|G1619-04|Galileo|GEEK|Jupiter|Loki Max|Loki MiniPro|Loki Zero|NEO-01|NEXT|ONE XPLAYER|ONEXPLAYER|SLIDE|Win600|RC71L|RC73YA|RC72LA|RC73XA'
 priority = 1
-packages = 'steamos-manager inputplumber steamos-powerbuttond cachyos-handheld'
+packages = 'steamos-manager inputplumber steamos-powerbuttond'
 
 [handheld.steam-deck]
 desc = 'Valve Steam Deck'
 hwd_product_name_pattern = '(Jupiter|Galileo)'
 priority = 2
-packages = 'steamos-manager steamos-powerbuttond cachyos-handheld jupiter-fan-control steamdeck-dsp'
+packages = 'steamos-manager steamos-powerbuttond jupiter-fan-control steamdeck-dsp'
 conditional_packages = """
     if grep -q 'Galileo' /sys/devices/virtual/dmi/id/product_name; then
         echo 'galileo-mura'

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -3,7 +3,7 @@ desc = 'Generic handheld profile'
 class_ids = "0601"
 hwd_product_name_pattern = '^(83E1|83L3|83N6|83Q2|83Q3|83N0|83N1|AIR|AIR 1S|AIR 1S Limited|AIR Plus|AIR Pro|AOKZOE A1 AR07|AOKZOE A1 Pro|AOKZOE A1X|AYANEO 2|AYA NEO 2021|AYANEO 2021|AYANEO 2021 Pro|AYANEO 2021 Pro Retro Power|AYANEO 2S|AYANEO 3|AYA NEO FOUNDER|AYANEO GEEK 1S|AYANEO KUN|AYANEO NEXT|AYANEO NEXT Advance|AYANEO NEXT Pro|Claw A8 BZ2EM|FLIP 1S DS|FLIP DS|FLIP KB|G1617-01|G1618-03|G1618-04|G1618-05|G1619-04|GEEK|GEEK 1S|Loki Max|Loki MiniPro|Loki Zero|NEO-01|NEXT|NEXT Advance|NEXT Lite|NEXT Pro|ONE XPLAYER|ONEXPLAYER|ONEXPLAYER 2 ARP23|ONEXPLAYER 2 PRO ARP23|ONEXPLAYER 2 PRO ARP23 EVA-01|ONEXPLAYER F1|ONEXPLAYER F1 EVA-01|ONEXPLAYER F1 OLED|ONEXPLAYER F1Pro|ONEXPLAYER G1 A|ONEXPLAYER G1 i|ONEXPLAYER mini A07|ONEXPLAYER Mini Pro|ONEXPLAYER X1 A|ONEXPLAYER X1 i|ONEXPLAYER X1 mini|SLIDE|Win600)$'
 priority = 1
-packages = 'steamos-manager inputplumber steamos-powerbuttond cachyos-handheld'
+packages = 'steamos-manager inputplumber steamos-powerbuttond'
 conditional_packages = """
     if grep -q 'LENOVO' /sys/class/dmi/id/bios_vendor; then
         echo 'fwupd'
@@ -14,7 +14,7 @@ conditional_packages = """
 desc = 'Valve Steam Deck'
 hwd_product_name_pattern = '(Jupiter|Galileo)'
 priority = 2
-packages = 'steamos-manager steamos-powerbuttond cachyos-handheld jupiter-fan-control steamdeck-dsp'
+packages = 'steamos-manager steamos-powerbuttond jupiter-fan-control steamdeck-dsp'
 conditional_packages = """
     if grep -q 'Galileo' /sys/devices/virtual/dmi/id/product_name; then
         echo 'galileo-mura'


### PR DESCRIPTION
cachyos-handheld is installed as part of the online install process in calamares, hence it is redundant to also add it here in chwd.

This should workaround the issue introduced by [1] where the handheld profile is installed before the graphics profile, leading to conflicts with mesa causing installs to fail.

[1] https://github.com/CachyOS/chwd/commit/399c20fd858e023a5e930e8510293230be98ccda