### PR TITLE
profiles/virutalmachine: Remove WaylandEnable=false for GDM

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -309,9 +309,7 @@ EOF
             mkinitcpio -P
         fi
     fi
-    if [ -e /etc/gdm/custom.conf ]; then
-        sed -i -e 's|#WaylandEnable=false|WaylandEnable=false|g' /etc/gdm/custom.conf
-    fi"""
+"""
 pre_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf
 """


### PR DESCRIPTION
It was removed in GDM 50