### PR TITLE
scripts/chwd: fix mesa removal guard

### DIFF
--- a/scripts/chwd
+++ b/scripts/chwd
@@ -132,7 +132,7 @@ end
 local function remove(packages)
     local pkgs = ""
     for _, pkg in ipairs(split(packages)) do
-        if is_installed(pkg) and (pkg ~= "mesa" or pkg ~= "lib32-mesa") then
+        if is_installed(pkg) and (pkg ~= "mesa" and pkg ~= "lib32-mesa") then
             pkgs = pkgs .. " " .. pkg
         end
     end


### PR DESCRIPTION
## Summary

Fix the removal guard for `mesa` and `lib32-mesa` in `scripts/chwd`.

The previous condition used `or`:

```lua
pkg ~= "mesa" or pkg ~= "lib32-mesa"
````

This expression is always true, so `mesa` and `lib32-mesa` were not actually excluded from the removal list.
