### PR TITLE
Only match hardware virtualization as environment types

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -371,6 +371,7 @@ pub fn get_all_devices_of_profile(devices: &ListOfDevicesT, profile: &Profile) -
 
     if let Some(environment_types) = &profile.environment_types {
         let environment_type = Exec::cmd("systemd-detect-virt")
+            .arg("--vm")
             .capture()
             .expect("Failed to detect environment type")
             .stdout_str()


### PR DESCRIPTION
Otherwise, running inside chroot (as in installation through calamares) will not result in a matching profile, since systemd-detect-virt returns the container type rather than virtualization.